### PR TITLE
#540 #541

### DIFF
--- a/public/events/index.html
+++ b/public/events/index.html
@@ -157,7 +157,7 @@
             </div>
             <div class="form-section">
               <h5>3. Please enter text in the box below to share your information.</h5>
-              <textarea rows="12" maxlength="150" placeholder="Free text (150 characters)..." class ="form-control" id="inputReportText" ></textarea>
+              <textarea rows="12" placeholder="Free text" class ="form-control" id="inputReportText" ></textarea>
               <i> Optional</i>
               <input placeholder="name..." class="form-control" id="inputReportUserName">
             </div>

--- a/public/lib/leaflet/leaflet-src.js
+++ b/public/lib/leaflet/leaflet-src.js
@@ -9406,7 +9406,7 @@ var Popup = DivOverlay.extend({
 
 		this._tipContainer = create$1('div', prefix + '-tip-container', container);
 		this._tip = create$1('div', prefix + '-tip', this._tipContainer);
-
+		
 		if (this.options.closeButton) {
 			var closeButton = this._closeButton = create$1('a', prefix + '-close-button', container);
 			closeButton.href = '#close';

--- a/public/lib/leaflet/leaflet.css
+++ b/public/lib/leaflet/leaflet.css
@@ -459,6 +459,7 @@
 	margin-bottom: 20px;
 	}
 .leaflet-popup-content-wrapper {
+	width: 200px;
 	padding: 1px;
 	text-align: left;
 	border-radius: 12px;

--- a/public/report/index.html
+++ b/public/report/index.html
@@ -66,7 +66,7 @@
             </div>
             <div class="form-section">
               <h4>Please enter text in the box below to share your information.</h4>
-              <textarea rows="6" maxlength="150" placeholder="Free text (150 characters)..." style="width:100%;height:50vh;color:black;" id="inputReportText" ></textarea>
+              <textarea rows="6" placeholder="Free text ..." style="width:100%;height:50vh;color:black;" id="inputReportText" ></textarea>
               <i> Optional</i>
               <input placeholder="name..." style="width:100%;color:black;" id="inputReportUserName">
             </div>

--- a/public/resources/css/landing.css
+++ b/public/resources/css/landing.css
@@ -115,3 +115,27 @@ div.pac-container {
 .bottom-margined {
   margin-bottom: 5px;
 }
+ul#reportsTable{
+  padding: 10px;
+}
+ul#reportsTable li{
+  list-style: none;
+  padding-bottom: 20px;
+  border-bottom: 1px solid #ccc;
+  margin-bottom: 10px;
+}
+ul#reportsTable div{
+  padding-top: 14px;
+}
+ul#reportsTable li span{
+  display: inline-block;
+  max-width: 25%;
+  margin-right: 1em;
+  vertical-align: top;
+}
+label{
+display: block;
+}
+ul#reportsTable select{
+  width: 100%;
+}

--- a/public/resources/js/events.js
+++ b/public/resources/js/events.js
@@ -574,7 +574,7 @@ var mapReports = function(reports,mapForReports){
 
         if (feature.properties && feature.properties.content) {
             popupContent += '<i id="popupReportShare'+feature.properties.id+'" class="icon-link-ext icon-floating" style="font-size:12px;"></i>';
-            popupContent += 'Decription: '+ feature.properties.content.description + '<BR>';
+            popupContent += 'Decription: '+ feature.properties.content.description.substring(0, 150)+ ' ...  <BR>';
             popupContent += 'Tag: '+ feature.properties.content.report_tag + '<BR>';
             popupContent += 'Reporter: ' + feature.properties.content['username/alias'] + '<BR>';
             popupContent += 'Reported time: ' + feature.properties.created + '<BR>';

--- a/public/resources/js/landing.js
+++ b/public/resources/js/landing.js
@@ -499,7 +499,7 @@ var mapMissions = function(missions ){
 var mapReports = function(reports,mapForReports){
 
     $('#reportsContainer').html(
-        '<table class="table table-hover" id="reportsTable"><thead><tr><th>Open</th><th>Type</th><th>Description</th><th>Status</th><th>Select event</th></thead><tbody>'
+        '<ul class="table table-hover" id="reportsTable">'
     );
 
     function onEachFeature(feature, layer) {
@@ -508,7 +508,7 @@ var mapReports = function(reports,mapForReports){
         var reportsTableContent = '';
 
         if (feature.properties && feature.properties.content) {
-            popupContent += 'Decription: '+ feature.properties.content.description + '<BR>';
+            popupContent += 'Decription: '+ feature.properties.content.description.substring(0,150) + '...<BR>';
             popupContent += 'Tag: '+ feature.properties.content.report_tag + '<BR>';
             popupContent += 'Reporter: ' + feature.properties.content['username/alias'] + '<BR>';
             popupContent += 'Reported time: ' + feature.properties.created + '<BR>';
@@ -524,19 +524,18 @@ var mapReports = function(reports,mapForReports){
 
 
             $('#reportsTable').append(
-                '<tr id="reports-table-row-'+feature.properties.id+'"><td ><a href=\'#\' onclick=\'openReportPopup(' +
-              feature.properties.id +
-              ')\' class=\'contact-link btn btn-sm btn-primary\' title=\'Quick View\'><i class=\'glyphicon glyphicon-eye-open\'></i></a></td><td>' +
-              feature.properties.content.report_tag +
-              '</td><td>' +
-              feature.properties.content.description +
-              '</td><td>' +
-              '<select id="report-'+feature.properties.id+'">'+
+                `<li id="reports-table-row-${feature.properties.id}">
+                <span ><a href=\'#\' onclick=\'openReportPopup(${
+              feature.properties.id})\' class=\'contact-link btn btn-sm btn-primary\' title=\'Quick View\'><i class=\'glyphicon glyphicon-eye-open\'></i> Open</a></span>`+
+              `<span><label> Type  </label>${feature.properties.content.report_tag}</span>`+
+              `<span><label> Status  </label><select id="report-${feature.properties.id}">`+
                 '<option value="unconfirmed">unconfirmed</option>' +
                 '<option value="confirmed">confirmed</option>' +
                 '<option value="ignored">ignored</option>' +
-              '</select></td><td>' +
-              '<select id="events-for-report-'+feature.properties.id+'"></select></td></tr>'
+              '</select></span>' +
+              `<span><label> Assign Event </label><select id="events-for-report-${feature.properties.id}"></select></span>`+
+              `<div>Description ${feature.properties.content.description}</div></li>`
+
             );
 
             $('#report-'+feature.properties.id).val(feature.properties.status);


### PR DESCRIPTION
fixes #540 Report allow long text 
fixes #541 Adjust layout to display readable text

Popup box set width wider, content description set to substring limit of 150 with ellipse for text overflow 
<img width="1272" alt="screen shot 2018-08-10 at 10 04 46 pm" src="https://user-images.githubusercontent.com/10966917/43979280-82176756-9cea-11e8-8ac1-d033b1e9c434.png">

Convert `table` layout to `ul` for flex layout
<img width="426" alt="screen shot 2018-08-10 at 10 05 34 pm" src="https://user-images.githubusercontent.com/10966917/43979272-7a4e4f9e-9cea-11e8-8332-5d8dbe67fb7e.png">

