### PR TITLE
move map into create new event modal

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -98,140 +98,116 @@
           </div>
           <div class="modal-body">
             <div class="container-fluid">
-              <div class="row">
                 <!-- Map -->
-
+                <div class="form-section">
+                    <div class="mapSearch">
+                    <label>Double click to create bounding box</span>
+                    <div id="newEventMap"></div>
+                    </div>
+                    <div class="mapSearch">
+                        <input type="text" class="form-control" placeholder="Search address/location..." id="mapAddress">
+                        <label for="mapAddressLat">OR locate by coordinates:</label>
+                        <input type="text" class="form-control" value="" id="mapAddressLat" placeholder="Latitude">
+                        <input type="text" class="form-control" value="" id="mapAddressLng" placeholder="Longitude">
+                        <button type="button" class="btn btn-info btn-sm" id="mapAddressLocate"><span class="glyphicon glyphicon-search"></span></button>
+                    </div>
+                  </div>
                 <!-- Side pane -->
-                <div id="newEventSidepane" class="col-sm-12">
                   <div id="geocodingNotice"><strong>Note that the event coordinates (only) are sent to Google for geocoding events to country</strong></div>
                   <div id="newEventProperties">
-                        <div class="panel panel-default" style="margin-bottom:0px;">
-                          <div class="panel-body">
-                            <div class="form-group">
-                              <label for="inputEventName">Event Name</label>
-                              <input class="form-control"  id="inputEventName" placeholder="Event name ..." required>
-                            </div>
-                            <div class="form-group">
-                              <label for="inputEventDescription">Event Description</label>
-                              <input class="form-control"  id="inputEventDescription" placeholder="Event description ..." required>
-                            </div>
-                            <div class="form-group">
-                              <label for="selectType">Event Type</label>
+                    <div class="form-group">
+                      <label for="inputEventName">Event Name</label>
+                      <input class="form-control"  id="inputEventName" placeholder="Event name ..." required>
+                    </div>
+                    <div class="form-group">
+                      <label for="inputEventDescription">Event Description</label>
+                      <input class="form-control"  id="inputEventDescription" placeholder="Event description ..." required>
+                    </div>
+                    <div class="form-group">
+                      <label for="selectType">Event Type</label>
 
 
-                                <div>
-                                    <input class="newEventTypeBox" id="selectType0" type="checkbox" value="armed_conflict" /><label class="eventBox" for="selectType0">&nbsp Armed Conflict</label><br>
-                                    <input class="newEventTypeBox" id="selectType1" type="checkbox" value="disease_outbreak" /><label class="eventBox" for="selectType1">&nbsp Disease Outbreak</label><br>
-                                    <div id="divDisease" style="display:none; margin-left: 20px;">
-                                        <input class="newSubEventTypeBox" id="diseaseType0" type="checkbox" value="Cholera" /><label class="eventBox" for="diseaseType0">&nbsp Cholera</label><br>
-                                        <input class="newSubEventTypeBox" id="diseaseType1" type="checkbox" value="Ebola" /><label class="eventBox" for="diseaseType1">&nbsp Ebola</label><br>
-                                        <input class="newSubEventTypeBox" id="diseaseType2" type="checkbox" value="Dengue" /><label class="eventBox" for="diseaseType2">&nbsp Dengue</label><br>
-                                        <input class="newSubEventTypeBox" id="diseaseType3" type="checkbox" value="Malaria" /><label class="eventBox" for="diseaseType3">&nbsp Malaria</label><br>
-                                        <input class="newSubEventTypeBox" id="diseaseType4" type="checkbox" value="Measles" /><label class="eventBox" for="diseaseType4">&nbsp Measles</label><br>
-                                        <input class="newSubEventTypeBox" id="diseaseType5" type="checkbox" value="Meningococcal Meningitis" /><label class="eventBox" for="diseaseType5">&nbsp Meningococcal Meningitis</label><br>
-                                        <input class="newSubEventTypeBox" id="diseaseType6" type="checkbox" value="Yellow Fever" /><label class="eventBox" for="diseaseType6">&nbsp Yellow Fever</label><br>
-                                        <input class="newSubEventTypeBox" id="diseaseType7" type="checkbox" value="Other Disease" /><label class="eventBox" for="diseaseType7">&nbsp Other (Specify)</label>
-                                        <div class="form-group" id="divOtherDisease"  style="display:none;">
-                                            <input type="text" id="diseaseType8" class="form-control" placeholder="(Specify)" >
-                                        </div>
-                                    </div>
-                                    <input class="newEventTypeBox" id="selectType2" type="checkbox" value="displacement" /><label for="selectType2" class="eventBox">&nbsp Displacement</label><br>
-                                    <input class="newEventTypeBox" id="selectType3" type="checkbox" value="malnutrition" /><label for="selectType3" class="eventBox">&nbsp Malnutrition</label><br>
-                                    <input class="newEventTypeBox" id="selectType4" type="checkbox" value="natural_disaster" /><label for="selectType4" class="eventBox">&nbsp Natural Disaster</label><br>
-                                    <div id="divNaturalDisaster" style="display:none; margin-left: 20px;">
-                                        <input class="newSubEventTypeBox" id="disasterType0" type="checkbox" value="drought" /><label for="disasterType0" class="eventBox">&nbsp Drought</label><br>
-                                        <input class="newSubEventTypeBox" id="disasterType1" type="checkbox" value="earthquake" /><label for="disasterType1" class="eventBox">&nbsp Earthquake</label><br>
-                                        <input class="newSubEventTypeBox" id="disasterType2" type="checkbox" value="flood" /><label for="disasterType2" class="eventBox">&nbsp Flood</label><br>
-                                        <input class="newSubEventTypeBox" id="disasterType3" type="checkbox" value="tsunami" /><label for="disasterType3" class="eventBox">&nbsp Tsunami</label><br>
-                                        <input class="newSubEventTypeBox" id="disasterType4" type="checkbox" value="typhoon" /><label for="disasterType4" class="eventBox">&nbsp Typhoon</label><br>
-                                        <input class="newSubEventTypeBox" id="disasterType5" type="checkbox" value="volcano" /><label for="disasterType5" class="eventBox">&nbsp Volcano</label><br>
-                                        <input class="newSubEventTypeBox" id="disasterType6" type="checkbox" value="landslides" /><label for="disasterType6" class="eventBox">&nbsp Landslides</label><br>
-                                        <input class="newSubEventTypeBox" id="disasterType7" type="checkbox" value="other disaster" /><label for="disasterType7" class="eventBox">&nbsp Other (Specify)</label>
-                                        <div class="form-group" id="divOtherDisaster"  style="display:none;">
-                                            <input type="text" id="disasterType8" class="form-control" placeholder="(Specify)" >
-                                        </div>
-                                    </div>
-                                    <input class="newEventTypeBox" id="selectType5" type="checkbox" value="search_and_rescue" /><label for="selectType5" class="eventBox">&nbsp Search & Rescue</label><br>
-                                    <input class="newEventTypeBox" id="selectType6" type="checkbox" value="other" /><label for="selectType6" class="eventBox">&nbsp Other (Specify)</label>
+                        <div>
+                            <input class="newEventTypeBox" id="selectType0" type="checkbox" value="armed_conflict" /><label class="eventBox" for="selectType0">&nbsp Armed Conflict</label><br>
+                            <input class="newEventTypeBox" id="selectType1" type="checkbox" value="disease_outbreak" /><label class="eventBox" for="selectType1">&nbsp Disease Outbreak</label><br>
+                            <div id="divDisease" style="display:none; margin-left: 20px;">
+                                <input class="newSubEventTypeBox" id="diseaseType0" type="checkbox" value="Cholera" /><label class="eventBox" for="diseaseType0">&nbsp Cholera</label><br>
+                                <input class="newSubEventTypeBox" id="diseaseType1" type="checkbox" value="Ebola" /><label class="eventBox" for="diseaseType1">&nbsp Ebola</label><br>
+                                <input class="newSubEventTypeBox" id="diseaseType2" type="checkbox" value="Dengue" /><label class="eventBox" for="diseaseType2">&nbsp Dengue</label><br>
+                                <input class="newSubEventTypeBox" id="diseaseType3" type="checkbox" value="Malaria" /><label class="eventBox" for="diseaseType3">&nbsp Malaria</label><br>
+                                <input class="newSubEventTypeBox" id="diseaseType4" type="checkbox" value="Measles" /><label class="eventBox" for="diseaseType4">&nbsp Measles</label><br>
+                                <input class="newSubEventTypeBox" id="diseaseType5" type="checkbox" value="Meningococcal Meningitis" /><label class="eventBox" for="diseaseType5">&nbsp Meningococcal Meningitis</label><br>
+                                <input class="newSubEventTypeBox" id="diseaseType6" type="checkbox" value="Yellow Fever" /><label class="eventBox" for="diseaseType6">&nbsp Yellow Fever</label><br>
+                                <input class="newSubEventTypeBox" id="diseaseType7" type="checkbox" value="Other Disease" /><label class="eventBox" for="diseaseType7">&nbsp Other (Specify)</label>
+                                <div class="form-group" id="divOtherDisease"  style="display:none;">
+                                    <input type="text" id="diseaseType8" class="form-control" placeholder="(Specify)" >
                                 </div>
-
-
                             </div>
-                            <!--<div class="form-group" id="divNaturalDisaster" style="display:none;">
-                              <select class="form-control" id="inputDisasterType">
-                                <option value="" disabled selected>Please select ...</option>
-                                <option value="drought">Drought</option>
-                                <option value="earthquake">Earthquake</option>
-                                <option value="flood">Flood</option>
-                                <option value="tsunami">Tsunami</option>
-                                <option value="typhoon">Typhoon</option>
-                                <option value="volcano">Volcano</option>
-                                <option value="landslide">Landslide</option>
-                                <option value="">Other</option>
-                              </select>
+                            <input class="newEventTypeBox" id="selectType2" type="checkbox" value="displacement" /><label for="selectType2" class="eventBox">&nbsp Displacement</label><br>
+                            <input class="newEventTypeBox" id="selectType3" type="checkbox" value="malnutrition" /><label for="selectType3" class="eventBox">&nbsp Malnutrition</label><br>
+                            <input class="newEventTypeBox" id="selectType4" type="checkbox" value="natural_disaster" /><label for="selectType4" class="eventBox">&nbsp Natural Disaster</label><br>
+                            <div id="divNaturalDisaster" style="display:none; margin-left: 20px;">
+                                <input class="newSubEventTypeBox" id="disasterType0" type="checkbox" value="drought" /><label for="disasterType0" class="eventBox">&nbsp Drought</label><br>
+                                <input class="newSubEventTypeBox" id="disasterType1" type="checkbox" value="earthquake" /><label for="disasterType1" class="eventBox">&nbsp Earthquake</label><br>
+                                <input class="newSubEventTypeBox" id="disasterType2" type="checkbox" value="flood" /><label for="disasterType2" class="eventBox">&nbsp Flood</label><br>
+                                <input class="newSubEventTypeBox" id="disasterType3" type="checkbox" value="tsunami" /><label for="disasterType3" class="eventBox">&nbsp Tsunami</label><br>
+                                <input class="newSubEventTypeBox" id="disasterType4" type="checkbox" value="typhoon" /><label for="disasterType4" class="eventBox">&nbsp Typhoon</label><br>
+                                <input class="newSubEventTypeBox" id="disasterType5" type="checkbox" value="volcano" /><label for="disasterType5" class="eventBox">&nbsp Volcano</label><br>
+                                <input class="newSubEventTypeBox" id="disasterType6" type="checkbox" value="landslides" /><label for="disasterType6" class="eventBox">&nbsp Landslides</label><br>
+                                <input class="newSubEventTypeBox" id="disasterType7" type="checkbox" value="other disaster" /><label for="disasterType7" class="eventBox">&nbsp Other (Specify)</label>
+                                <div class="form-group" id="divOtherDisaster"  style="display:none;">
+                                    <input type="text" id="disasterType8" class="form-control" placeholder="(Specify)" >
+                                </div>
                             </div>
-                            <div class="form-group" id="divDisease"  style="display:none;">
-                              <select class="form-control" id="inputDiseaseType">
-                                <option value="" disabled selected>Please select ...</option>
-                                <option value="Cholera">Cholera</option>
-                                <option value="Ebola">Ebola</option>
-                                <option value="Dengue">Dengue</option>
-                                <option value="Malaria">Malaria</option>
-                                <option value="Measles">Measles</option>
-                                <option value="Meningococcal Meningitis">Meningococcal Meningitis</option>
-                                <option value="Yellow Fever">Yellow Fever</option>
-                                <option value="">Other</option>
-                              </select>
-                            </div>-->
-                            <div class="form-group" id="divOther"  style="display:none;">
-                              <input type="text" id="inputOther" class="form-control" placeholder="(Specify)" >
-                            </div>
-                            <div class="form-group">
-                              <label for="inputEvDateTime">Date and time of Event (local time of operator)</label>
-                              <input type="text" id="inputEvDateTime" class="form-control" placeholder="YYYY-MM-DD HH:MM" >
-                            </div>
-                            <div class="form-group" >
-                              <label for="inputEvStatus">Status</label>
-                              <select class="form-control" id="inputEvStatus">
-                                <option value="Monitoring">Monitoring </option>
-                                <option value="Exploration">Exploration</option>
-                                <option value="Intervention">Intervention</option>
-                                <option value="Completed Missions">Completed Missions</option>
-                              </select>
-                            </div>
-                            <div class="form-group">
-                              <label for="">Person in charge</label>
-                              <input type="text" id="inputInChargeName" class="form-control" placeholder="Name" >
-                              <input type="text" id="inputInChargePosition" class="form-control" placeholder="Position" >
-                            </div>
-                            <div class="form-group">
-                              <label for="inputSeverity">Severity details</label>
-                              <input type="text" id="inputSeverity" class="form-control" placeholder="Severity details ..." >
-                              <label for="inputSeverityScale" style="vertical-align:top;margin-top:5px;">Severity scale</label><div style="display:inline-block;margin-left:10%;" id="inputSeverityScale"></div>
-                            </div>
-                            <div class="form-group">
-                              <label for="inputSecurity">Security details</label>
-                              <textarea class="form-control" rows="1" id="inputSecurity" placeholder="Security details ..." required></textarea>
-                            </div>
-                            <div class="form-group">
-                              <label for="inputSharepointLink">Link to SharePoint folder</label>
-                              <input type="text" id="inputSharepointLink" class="form-control" placeholder="http://" >
-                            </div>
-                            <!--<button  type="button" id="nextEventTab" class="btn btn-msf" data-toggle="tab">Next </button>-->
-
-                          </div>
+                            <input class="newEventTypeBox" id="selectType5" type="checkbox" value="search_and_rescue" /><label for="selectType5" class="eventBox">&nbsp Search & Rescue</label><br>
+                            <input class="newEventTypeBox" id="selectType6" type="checkbox" value="other" /><label for="selectType6" class="eventBox">&nbsp Other (Specify)</label>
                         </div>
 
 
+                    </div>
+                    <div class="form-group" id="divOther"  style="display:none;">
+                      <input type="text" id="inputOther" class="form-control" placeholder="(Specify)" >
+                    </div>
+                    <div class="form-group">
+                      <label for="inputEvDateTime">Date and time of Event (local time of operator)</label>
+                      <input type="text" id="inputEvDateTime" class="form-control" placeholder="YYYY-MM-DD HH:MM" >
+                    </div>
+                    <div class="form-group" >
+                      <label for="inputEvStatus">Status</label>
+                      <select class="form-control" id="inputEvStatus">
+                        <option value="Monitoring">Monitoring </option>
+                        <option value="Exploration">Exploration</option>
+                        <option value="Intervention">Intervention</option>
+                        <option value="Completed Missions">Completed Missions</option>
+                      </select>
+                    </div>
+                    <div class="form-group">
+                      <label for="">Person in charge</label>
+                      <input type="text" id="inputInChargeName" class="form-control" placeholder="Name" >
+                      <input type="text" id="inputInChargePosition" class="form-control" placeholder="Position" >
+                    </div>
+                    <div class="form-group">
+                      <label for="inputSeverity">Severity details</label>
+                      <input type="text" id="inputSeverity" class="form-control" placeholder="Severity details ..." >
+                      <label for="inputSeverityScale" style="vertical-align:top;margin-top:5px;">Severity scale</label><div style="display:inline-block;margin-left:10%;" id="inputSeverityScale"></div>
+                    </div>
+                    <div class="form-group">
+                      <label for="inputSecurity">Security details</label>
+                      <textarea class="form-control" rows="1" id="inputSecurity" placeholder="Security details ..." required></textarea>
+                    </div>
+                    <div class="form-group">
+                      <label for="inputSharepointLink">Link to SharePoint folder</label>
+                      <input type="text" id="inputSharepointLink" class="form-control" placeholder="http://" >
+                    </div>
+                    <!--<button  type="button" id="nextEventTab" class="btn btn-msf" data-toggle="tab">Next </button>-->
                   </div>
-                </div>
               </div>
             </div>
-          </div>
           <div class="modal-footer">
             <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
             <button type="button" id="createEvent" class="btn btn-msf">Create</button>
           </div>
+      </div>
         </div>
       </div>
     </div>
@@ -648,31 +624,7 @@
       <div class="container-fluid" style="margin-top:5px;">
         <div class="row">
           <div class="col-md-8">
-            <span style="font-weight:bold;">Double click on approximate location of event on map to create a new event.</span>
-            <div class="form-section">
-              <div class="row">
-                <div class="col-sm-12">
-                  <div class="form-group">
-                    <input type="text" class="form-control" placeholder="Search address/location..." id="mapAddress">
-                  </div>
-                </div>
-              </div>
-              <div class="row bottom-margined">
-                <div class="col-sm-3">
-                  <label for="mapAddressLat">OR locate by coordinates:</label>
-                </div>
-                <div class="col-sm-2">
-                  <input type="text" class="form-control" value="" id="mapAddressLat" placeholder="Latitude">
-                </div>
-                <div class="col-sm-2">
-                  <input type="text" class="form-control" value="" id="mapAddressLng" placeholder="Longitude">
-                </div>
-                <div class="col-sm-5">
-                  <button type="button" class="btn btn-info btn-sm" id="mapAddressLocate"><span class="glyphicon glyphicon-search"></span></button>
-                </div>
-              </div>
-              <div id="mainMap" ></div>
-            </div>
+            <div id="mainMap" ></div>
           </div>
 
           <div id="sidepane" class="col-md-4" >
@@ -689,10 +641,11 @@
                 <!--event tab menu-->
                 <div id="event" class="tab-pane active">
                     <ul class="nav nav-tabs" id="event_tabs">
-                        <li class="active"><a href="#event_monitoring" data-toggle="tab">Monitoring & Assessment</a></li>
-                        <li><a href="#event_ongoing" data-toggle="tab">Ongoing MSF Responses</a></li>
-                        <li><a href="#event_missions" data-toggle="tab">Previous MSF Responses</a></li>
+                        <li class="active"><a href="#event_monitoring" data-toggle="tab">Monitoring</a></li>
+                        <li><a href="#event_ongoing" data-toggle="tab">Ongoing</a></li>
+                        <li><a href="#event_missions" data-toggle="tab">Previous</a></li>
                         <li><a href="#event_RSS" data-toggle="tab">RSS Feeds</a></li>
+                        <li><a id="new_event">Create <span class="glyphicon glyphicon-plus-sign"></span></a></li>
                     </ul>
 
                     <!--event tab content-->

--- a/public/resources/css/landing.css
+++ b/public/resources/css/landing.css
@@ -1,7 +1,7 @@
 html, body { height: 100% }
 
 #mainMap {
-  height:CALC(100vh - 170px);
+  height:CALC(100vh - 60px);
   width:100%;
 }
 

--- a/public/resources/css/new-event.css
+++ b/public/resources/css/new-event.css
@@ -19,3 +19,33 @@
   display:inline-block;
   cursor:pointer;
 }
+#newEventMap{
+    height: 50vh;
+    width: 100%;
+    display: block;
+}
+
+.mapSearch{
+    width: 48%;
+    display: inline-block;
+}
+
+.nav-tabs li a,
+.nav-tabs li.active a,
+.nav-tabs li.active a:focus,
+.nav-tabs li.active a:hover{
+    border: none;
+}
+
+.nav-tabs li a{
+    padding: 8px 10px; 
+}
+.nav-tabs li.active a{
+    color: #000;
+    font-weight: bold;
+}
+
+#new_event{
+    color: #F00;
+    cursor: pointer;
+}

--- a/public/resources/js/events.js
+++ b/public/resources/js/events.js
@@ -1578,19 +1578,6 @@ var vmObject = {
 
             var eventMarker = L.marker(eventDefaultLatLng).addTo(eventMap);
 
-            /*
-              var latlng = null;
-              eventMap.on('click', function(e) {
-                if (eventMarker) {
-                  eventMap.removeLayer(eventMarker);
-                }
-                latlng = e.latlng;
-                Vue.set(vm.currentEventGeometry, 'coordinates', [latlng.lng, latlng.lat]);
-                eventMarker = L.marker(e.latlng).addTo(eventMap);
-              });
-              */
-            /** eventMap >> */
-
             // Add some base tiles
             var eventMapboxTerrain = L.tileLayer('https://api.mapbox.com/styles/v1/acrossthecloud/cj9t3um812mvr2sqnr6fe0h52/tiles/256/{z}/{x}/{y}?access_token=pk.eyJ1IjoiYWNyb3NzdGhlY2xvdWQiLCJhIjoiY2lzMWpvOGEzMDd3aTJzbXo4N2FnNmVhYyJ9.RKQohxz22Xpyn4Y8S1BjfQ', {
                 attribution: '© Mapbox © OpenStreetMap © DigitalGlobe',

--- a/public/resources/js/landing.js
+++ b/public/resources/js/landing.js
@@ -1094,15 +1094,18 @@ var latlng = null;
 
 var areaSelect = null;
 
-mainMap.on('dblclick', function(dblclickEvent) {
-    if (!areaSelect) {
-        areaSelect = L.areaSelect({width:300, height:200});
-        areaSelect.addTo(mainMap);
-    } else {
-        $('#newEventModal').modal('show');
-    }
+// mainMap.on('dblclick', function(dblclickEvent) {
+//     if (!areaSelect) {
+//         areaSelect = L.areaSelect({width:300, height:200});
+//         areaSelect.addTo(mainMap);
+//     } else {
+//         $('#newEventModal').modal('show');
+//     }
+// });
+$('#new_event').on('click', function(){
+    $('#newEventModal').modal('show');
+     loadNewEventMap();
 });
-
 
 $('#contSearchTerm').on('input',function(){
     if ($('#inputContactType').val()!=='') {

--- a/public/resources/js/new-event.js
+++ b/public/resources/js/new-event.js
@@ -1,6 +1,6 @@
 /*eslint no-unused-vars: off*/
 
-//var newEventMap = L.map('newEventMap').setView([20, 110], 4);
+
 function clearGlobalVars(){
     // clear global vars
     if (report_id_for_event) {
@@ -55,39 +55,45 @@ $('#analyticsModal').on('shown.bs.modal', function(){
     $('body').addClass('modal-open');
 });
 
-// Add some base tiles
-/*
-var NEmapboxTerrain = L.tileLayer('https://api.mapbox.com/styles/v1/acrossthecloud/cj9t3um812mvr2sqnr6fe0h52/tiles/256/{z}/{x}/{y}?access_token=pk.eyJ1IjoiYWNyb3NzdGhlY2xvdWQiLCJhIjoiY2lzMWpvOGEzMDd3aTJzbXo4N2FnNmVhYyJ9.RKQohxz22Xpyn4Y8S1BjfQ', {
-    attribution: '© Mapbox © OpenStreetMap © DigitalGlobe',
-    minZoom: 0,
-    maxZoom: 18
-}).addTo(newEventMap);
 
-// Add some satellite tiles
-var NEmapboxSatellite = L.tileLayer('https://api.mapbox.com/styles/v1/mapbox/satellite-streets-v9/tiles/256/{z}/{x}/{y}?access_token=pk.eyJ1IjoidG9tYXN1c2VyZ3JvdXAiLCJhIjoiY2o0cHBlM3lqMXpkdTJxcXN4bjV2aHl1aCJ9.AjzPLmfwY4MB4317m4GBNQ', {
-    attribution: '© Mapbox © OpenStreetMap © DigitalGlobe'
-});
 
-var NEbaseMaps = {
-    'Terrain': NEmapboxTerrain,
-    'Satellite' : NEmapboxSatellite
-};
+function loadNewEventMap(){
+    var newEventMap = L.map('newEventMap', {dragging: !L.Browser.mobile, tap:false});
+    console.log('FIRE FIRE ___ ')
 
-var NEoverlayMaps = {};
+    // Add some base tiles
 
- var NElayerControl = L.control.layers(NEbaseMaps, NEoverlayMaps, {'position':'bottomleft'}).addTo(newEventMap);
-*/
-// var marker;
+    var NEmapboxTerrain = L.tileLayer('https://api.mapbox.com/styles/v1/acrossthecloud/cj9t3um812mvr2sqnr6fe0h52/tiles/256/{z}/{x}/{y}?access_token=pk.eyJ1IjoiYWNyb3NzdGhlY2xvdWQiLCJhIjoiY2lzMWpvOGEzMDd3aTJzbXo4N2FnNmVhYyJ9.RKQohxz22Xpyn4Y8S1BjfQ', {
+        attribution: '© Mapbox © OpenStreetMap © DigitalGlobe',
+        minZoom: 0,
+        maxZoom: 18
+    }).addTo(newEventMap);
+    // Add some satellite tiles
+    var NEmapboxSatellite = L.tileLayer('https://api.mapbox.com/styles/v1/mapbox/satellite-streets-v9/tiles/256/{z}/{x}/{y}?access_token=pk.eyJ1IjoidG9tYXN1c2VyZ3JvdXAiLCJhIjoiY2o0cHBlM3lqMXpkdTJxcXN4bjV2aHl1aCJ9.AjzPLmfwY4MB4317m4GBNQ', {
+        attribution: '© Mapbox © OpenStreetMap © DigitalGlobe'
+    });
 
-/*
-newEventMap.on('click', function(e) {
-    if(marker)
-        newEventMap.removeLayer(marker);
-    latlng = e.latlng; // e is an event object (MouseEvent in this case)
-    marker = L.marker(e.latlng).addTo(newEventMap);
-});
+    var NEbaseMaps = {
+        'Terrain': NEmapboxTerrain,
+        'Satellite' : NEmapboxSatellite
+    };
 
-*/
+    var NEoverlayMaps = {};
+
+     var NElayerControl = L.control.layers(NEbaseMaps, NEoverlayMaps, {'position':'bottomleft'}).addTo(newEventMap);
+
+    var marker;
+    setTimeout(newEventMap.setView([-6.8, 108.7], 7), 300);
+    setTimeout(newEventMap.invalidateSize(), 400);
+
+    newEventMap.on('click', function(e) {
+        if(marker)
+            newEventMap.removeLayer(marker);
+        latlng = e.latlng; // e is an event object (MouseEvent in this case)
+        marker = L.marker(e.latlng).addTo(newEventMap);
+    });
+}
+
 
 /**
  * refresh the landing page to show up a new event


### PR DESCRIPTION
@LucieGueuning 

this feeds into our conversation of moving `double click to create event` input fields into create new event modal 

<img width="630" alt="screen shot 2018-08-27 at 6 08 38 pm" src="https://user-images.githubusercontent.com/10966917/44670901-3fc1a500-aa24-11e8-9568-e7e96dddd3de.png">

please confirm the filter fields 
>> `Monitoring / Exploration / Ongoing Intervention (MSF activity) / Complete` 
of which `Complete` is `Previous`
and where does Assessment fall ? 

at the moment I have these 
![event tab nav](https://user-images.githubusercontent.com/10966917/44671162-02114c00-aa25-11e8-89a3-1773b778a9db.png)


@matthewberryman @mehrdadgit 
while moving map into newEventModal, i notice some crumbs of newEventMap from before, was map originally inside modal?

if so how can i load the map correctly, it's only partially loading, even though I've call `.invalidateSize()`
